### PR TITLE
Prevent multiple Firebase listener attachments

### DIFF
--- a/app/src/main/java/com/firebase/samples/logindemo/MainActivity.java
+++ b/app/src/main/java/com/firebase/samples/logindemo/MainActivity.java
@@ -71,7 +71,7 @@ public class MainActivity extends ActionBarActivity implements
     private AuthData mAuthData;
     
     /* Listener for Firebase session changes */
-    private Firebase.AuthStateListener firebaseAuthStateListener;
+    private Firebase.AuthStateListener mAuthStateListener;
 
     /* *************************************
      *              FACEBOOK               *
@@ -223,7 +223,7 @@ public class MainActivity extends ActionBarActivity implements
         mAuthProgressDialog.setCancelable(false);
         mAuthProgressDialog.show();
 
-        firebaseAuthStateListener = new Firebase.AuthStateListener() {
+        mAuthStateListener = new Firebase.AuthStateListener() {
             @Override
             public void onAuthStateChanged(AuthData authData) {
                 mAuthProgressDialog.hide();
@@ -232,7 +232,7 @@ public class MainActivity extends ActionBarActivity implements
         };
         /* Check if the user is authenticated with Firebase already. If this is the case we can set the authenticated
          * user and hide hide any login buttons */
-        mFirebaseRef.addAuthStateListener(firebaseAuthStateListener);
+        mFirebaseRef.addAuthStateListener(mAuthStateListener);
     }
 
     @Override
@@ -244,7 +244,7 @@ public class MainActivity extends ActionBarActivity implements
         }
         
         // if changing configurations, stop tracking firebase session.
-        mFirebaseRef.removeAuthStateListener(firebaseAuthStateListener);
+        mFirebaseRef.removeAuthStateListener(mAuthStateListener);
     }
 
     /**

--- a/app/src/main/java/com/firebase/samples/logindemo/MainActivity.java
+++ b/app/src/main/java/com/firebase/samples/logindemo/MainActivity.java
@@ -69,6 +69,9 @@ public class MainActivity extends ActionBarActivity implements
 
     /* Data from the authenticated user */
     private AuthData mAuthData;
+    
+    /* Listener for Firebase session changes */
+    private Firebase.AuthStateListener firebaseAuthStateListener;
 
     /* *************************************
      *              FACEBOOK               *
@@ -220,15 +223,16 @@ public class MainActivity extends ActionBarActivity implements
         mAuthProgressDialog.setCancelable(false);
         mAuthProgressDialog.show();
 
-        /* Check if the user is authenticated with Firebase already. If this is the case we can set the authenticated
-         * user and hide hide any login buttons */
-        mFirebaseRef.addAuthStateListener(new Firebase.AuthStateListener() {
+        firebaseAuthStateListener = new Firebase.AuthStateListener() {
             @Override
             public void onAuthStateChanged(AuthData authData) {
                 mAuthProgressDialog.hide();
                 setAuthenticatedUser(authData);
             }
-        });
+        };
+        /* Check if the user is authenticated with Firebase already. If this is the case we can set the authenticated
+         * user and hide hide any login buttons */
+        mFirebaseRef.addAuthStateListener(firebaseAuthStateListener);
     }
 
     @Override
@@ -238,6 +242,9 @@ public class MainActivity extends ActionBarActivity implements
         if (mFacebookAccessTokenTracker != null) {
             mFacebookAccessTokenTracker.stopTracking();
         }
+        
+        // if changing configurations, stop tracking firebase session.
+        mFirebaseRef.removeAuthStateListener(firebaseAuthStateListener);
     }
 
     /**


### PR DESCRIPTION
I'm not sure this is right, but In my app I would get multiple calls to the firebaseAuthStateListener when rotating or re entering my app. I guess this was because we are attaching the listener on the onCreate method, but never detaching it.
